### PR TITLE
issue3832: 자바 SDK에 커서 쿼리 ID, 필드 순서, 쿼리 결과 필드 타입 정보 지원

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>logpresso</groupId>
 	<artifactId>logpresso-sdk-java</artifactId>
-	<version>1.0.0-6</version>
+	<version>1.1.0</version>
 	<packaging>jar</packaging>
 	<name>Logpresso SDK for Java</name>
 
 	<organization>
-		<name>Eediom, Inc</name>
+		<name>Logpresso, Inc</name>
 	</organization>
 
 	<properties>

--- a/src/main/java/com/logpresso/client/AbstractSession.java
+++ b/src/main/java/com/logpresso/client/AbstractSession.java
@@ -136,10 +136,16 @@ public abstract class AbstractSession implements Session {
 	}
 
 	public void addListener(TrapListener listener) {
+		if (listener == null)
+			throw new IllegalArgumentException("trap listener should be not null");
+
 		listeners.add(listener);
 	}
 
 	public void removeListener(TrapListener listener) {
+		if (listener == null)
+			throw new IllegalArgumentException("trap listener should be not null");
+
 		listeners.remove(listener);
 	}
 

--- a/src/main/java/com/logpresso/client/Cursor.java
+++ b/src/main/java/com/logpresso/client/Cursor.java
@@ -17,13 +17,27 @@ package com.logpresso.client;
 
 import java.io.Closeable;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * 커서는 쿼리 결과를 순회하는 인터페이스를 제공합니다.
- * 
- * @author xeraph@eediom.com
- * 
  */
 public interface Cursor extends Iterator<Tuple>, Closeable {
+	int getQueryId();
 
+	/**
+	 * 필드 정렬 순서를 반환합니다. 필드 정렬 순서에 표시된 필드가 쿼리 결과에 존재하지 않을 수 있으며, 쿼리 결과의 모든 필드를 나열하지
+	 * 않습니다. 필드 정렬 순서는 실제 출력 필드에서 고려되어야 할 순서를 의미하므로, 필드 정렬 순서에 나타나지 않은 결과 필드는 사전순으로
+	 * 정렬해야 합니다.
+	 * 
+	 * @return 필드 정렬 순서 목록. 필드 정렬 순서가 정의되지 않은 경우 null을 반환합니다.
+	 */
+	List<String> getFieldOrder();
+
+	/**
+	 * queryWithSummary()를 사용하거나, 요약 정보를 생성하도록 설정한 쿼리의 경우 필드 요약 정보를 반환합니다.
+	 * 
+	 * @return 필드 요약 정보. 요약 생성 옵션이 지정되지 않은 쿼리는 null을 반환합니다.
+	 */
+	List<FieldSummary> getSummary();
 }

--- a/src/main/java/com/logpresso/client/FieldSummary.java
+++ b/src/main/java/com/logpresso/client/FieldSummary.java
@@ -1,0 +1,79 @@
+package com.logpresso.client;
+
+import java.util.Map;
+
+public class FieldSummary {
+	private String name;
+	private String type;
+	private long count;
+	private Object min;
+	private Object max;
+	private Double avg;
+
+	public static FieldSummary parse(Map<String, Object> m) {
+		FieldSummary f = new FieldSummary();
+		f.setName((String) m.get("name"));
+		f.setType((String) m.get("type"));
+		f.setCount(((Number) m.get("count")).longValue());
+		f.setMin(m.get("min"));
+		f.setMax(m.get("max"));
+		if (m.get("avg") != null)
+			f.setAvg(((Number) m.get("avg")).doubleValue());
+		return f;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+
+	public Object getMin() {
+		return min;
+	}
+
+	public void setMin(Object min) {
+		this.min = min;
+	}
+
+	public Object getMax() {
+		return max;
+	}
+
+	public void setMax(Object max) {
+		this.max = max;
+	}
+
+	public Double getAvg() {
+		return avg;
+	}
+
+	public void setAvg(Double avg) {
+		this.avg = avg;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("field %s (type=%s, count=%d, min=%s, max=%s, avg=%f)", name, type, count,
+				min != null ? min.toString() : null, max != null ? max.toString() : null, avg);
+	}
+
+}

--- a/src/main/java/com/logpresso/client/Query.java
+++ b/src/main/java/com/logpresso/client/Query.java
@@ -55,6 +55,12 @@ public class Query {
 	// @since 0.9.1
 	private List<SubQuery> subQueries = new ArrayList<SubQuery>();
 
+	// @since 1.1.0
+	private List<String> fieldOrder;
+
+	// @since 1.1.0
+	private List<FieldSummary> fieldSummary;
+
 	public Query(Logpresso client, int id, String queryString) {
 		this.client = client;
 		this.id = id;
@@ -346,6 +352,22 @@ public class Query {
 
 	public void setCancelReason(String cancelReason) {
 		this.cancelReason = cancelReason;
+	}
+
+	public List<String> getFieldOrder() {
+		return fieldOrder;
+	}
+
+	public void setFieldOrder(List<String> fieldOrder) {
+		this.fieldOrder = fieldOrder;
+	}
+
+	public List<FieldSummary> getFieldSummary() {
+		return fieldSummary;
+	}
+
+	public void setFieldSummary(List<FieldSummary> fieldSummary) {
+		this.fieldSummary = fieldSummary;
 	}
 
 	private class WaitingCondition {

--- a/src/main/java/com/logpresso/client/QueryRequest.java
+++ b/src/main/java/com/logpresso/client/QueryRequest.java
@@ -8,12 +8,12 @@ public class QueryRequest {
 	private Map<String, Object> queryContext;
 	private boolean useSummary;
 
-	public String getQueryString() {
-		return queryString;
+	public QueryRequest(String queryString) {
+		this.queryString = queryString;
 	}
 
-	public void setQueryString(String queryString) {
-		this.queryString = queryString;
+	public String getQueryString() {
+		return queryString;
 	}
 
 	public StreamingResultSet getStreamingResultSet() {

--- a/src/main/java/com/logpresso/client/QueryRequest.java
+++ b/src/main/java/com/logpresso/client/QueryRequest.java
@@ -1,0 +1,42 @@
+package com.logpresso.client;
+
+import java.util.Map;
+
+public class QueryRequest {
+	private String queryString;
+	private StreamingResultSet rs;
+	private Map<String, Object> queryContext;
+	private boolean useSummary;
+
+	public String getQueryString() {
+		return queryString;
+	}
+
+	public void setQueryString(String queryString) {
+		this.queryString = queryString;
+	}
+
+	public StreamingResultSet getStreamingResultSet() {
+		return rs;
+	}
+
+	public void setStreamingResultSet(StreamingResultSet rs) {
+		this.rs = rs;
+	}
+
+	public Map<String, Object> getQueryContext() {
+		return queryContext;
+	}
+
+	public void setQueryContext(Map<String, Object> queryContext) {
+		this.queryContext = queryContext;
+	}
+
+	public boolean isUseSummary() {
+		return useSummary;
+	}
+
+	public void setUseSummary(boolean useSummary) {
+		this.useSummary = useSummary;
+	}
+}

--- a/src/main/java/com/logpresso/client/http/impl/WebSocketSession.java
+++ b/src/main/java/com/logpresso/client/http/impl/WebSocketSession.java
@@ -189,7 +189,7 @@ public class WebSocketSession extends AbstractSession implements WebSocketListen
 			try {
 				synchronized (sendLock) {
 					// send msgbus ping
-					websocket.send("ping");
+					websocket.sendPing();
 				}
 			} catch (Throwable t) {
 				// ignore ping fail


### PR DESCRIPTION
https://github.com/logpresso/ent-/issues/3832

쿼리 결과에 대한 필드 요약 정보 목록, 필드 순서를 조회하는 인터페이스를 추가했습니다.

- Cursor 인터페이스에 getFieldOrder(), getSummary() 추가
- Logpresso.queryWithSummary() 메소드 추가
- 옵션 추가에 따라 메소드 오버로딩이 계속 증가하여 `createQuery(QueryRequest)` 로 추가
- Logpresso.waitUntil(queryId) 오버로딩 추가
  * 거의 대부분의 코드는 count 매개변수를 null로 쓰기 때문에 편의상 메소드 추가함 
- Logpresso.getFieldOrder(queryId) 메소드 추가
  * 자동완성으로 필드 정렬 순서를 발견할 수 있도록 추가함